### PR TITLE
Fix product badge stacking and hide landing nav extras

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,14 +1,10 @@
 [build]
-command = "npm ci && npm run build"
+command = "npm run build"
 publish = "dist"
 
 [build.environment]
 NODE_VERSION = "22"
 
-[functions]
-directory = "netlify/functions"
-
-# SPA fallback (React Router)
 [[redirects]]
 from = "/*"
 to = "/index.html"

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,6 +1,8 @@
-import { Link, NavLink } from "react-router-dom";
+import { Link, NavLink, useLocation } from "react-router-dom";
 
 export default function Header() {
+  const { pathname } = useLocation();
+  const showNavExtras = pathname !== "/";
   const linkBase = "px-3 py-2 text-sm font-medium hover:opacity-80";
   const active = "text-emerald-600";
   const idle = "text-slate-700";
@@ -12,18 +14,22 @@ export default function Header() {
           Admiral Energy
         </Link>
         <div className="flex items-center gap-1">
-          <NavLink
-            to="/catalog"
-            className={({ isActive }) => `${linkBase} ${isActive ? active : idle}`}
-          >
-            Catalog
-          </NavLink>
-          <NavLink
-            to="/calculator"
-            className={({ isActive }) => `${linkBase} ${isActive ? active : idle}`}
-          >
-            Calculator
-          </NavLink>
+          {showNavExtras && (
+            <>
+              <NavLink
+                to="/catalog"
+                className={({ isActive }) => `${linkBase} ${isActive ? active : idle}`}
+              >
+                Catalog
+              </NavLink>
+              <NavLink
+                to="/calculator"
+                className={({ isActive }) => `${linkBase} ${isActive ? active : idle}`}
+              >
+                Calculator
+              </NavLink>
+            </>
+          )}
           <a href="#lead" className={`${linkBase} ${idle}`}>
             Get Quote
           </a>

--- a/src/index.css
+++ b/src/index.css
@@ -3,8 +3,8 @@
 @tailwind components;
 @tailwind utilities;
 
-/* rest of styles... */
-
 @layer base {
-	html { font-family: Inter, ui-sans-serif, system-ui, sans-serif; }
+  html {
+    font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  }
 }

--- a/src/pages/ProductCatalog.js
+++ b/src/pages/ProductCatalog.js
@@ -318,7 +318,8 @@ const ProductCatalog = () => {
                     borderRadius: '20px',
                     fontSize: '12px',
                     fontWeight: 'bold',
-                    boxShadow: '0 4px 12px rgba(0,0,0,0.2)'
+                    boxShadow: '0 4px 12px rgba(0,0,0,0.2)',
+                    zIndex: 30
                 }, children: panel.badge }), _jsxs("div", { style: {
                     width: '100%',
                     height: '180px',
@@ -330,7 +331,8 @@ const ProductCatalog = () => {
                     gridTemplateRows: 'repeat(10, 1fr)',
                     gap: '2px',
                     padding: '8px',
-                    position: 'relative'
+                    position: 'relative',
+                    zIndex: 0
                 }, children: [Array.from({ length: 60 }).map((_, i) => (_jsx("div", { style: {
                             background: 'rgba(201, 166, 72, 0.15)',
                             border: '1px solid rgba(201, 166, 72, 0.4)',
@@ -345,7 +347,8 @@ const ProductCatalog = () => {
                             borderRadius: '8px',
                             fontSize: '14px',
                             fontWeight: 'bold',
-                            boxShadow: '0 4px 12px rgba(0,0,0,0.3)'
+                            boxShadow: '0 4px 12px rgba(0,0,0,0.3)',
+                            zIndex: 20
                         }, children: [panel.watts, "W"] })] }), _jsx("div", { style: { color: BRAND.gold, fontSize: '13px', fontWeight: 'bold', marginBottom: '4px', letterSpacing: '0.05em' }, children: panel.manufacturer }), _jsx("h3", { style: { color: BRAND.navy, fontSize: '18px', fontWeight: 'bold', marginBottom: '12px', lineHeight: '1.3' }, children: panel.model }), _jsxs("div", { style: {
                     background: `linear-gradient(135deg, #d1fae5, #a7f3d0)`,
                     border: `3px solid #10b981`,
@@ -407,7 +410,8 @@ const ProductCatalog = () => {
                     borderRadius: '20px',
                     fontSize: '12px',
                     fontWeight: 'bold',
-                    boxShadow: '0 4px 12px rgba(0,0,0,0.2)'
+                    boxShadow: '0 4px 12px rgba(0,0,0,0.2)',
+                    zIndex: 30
                 }, children: battery.badge }), _jsxs("div", { style: {
                     width: '100%',
                     height: '180px',
@@ -418,7 +422,8 @@ const ProductCatalog = () => {
                     flexDirection: 'column',
                     alignItems: 'center',
                     justifyContent: 'center',
-                    position: 'relative'
+                    position: 'relative',
+                    zIndex: 0
                 }, children: [_jsx(Battery, { size: 64, style: { color: BRAND.gold }, strokeWidth: 1.5 }), _jsxs("div", { style: {
                             position: 'absolute',
                             top: '12px',
@@ -429,7 +434,8 @@ const ProductCatalog = () => {
                             borderRadius: '8px',
                             fontSize: '14px',
                             fontWeight: 'bold',
-                            boxShadow: '0 4px 12px rgba(0,0,0,0.3)'
+                            boxShadow: '0 4px 12px rgba(0,0,0,0.3)',
+                            zIndex: 20
                         }, children: [battery.capacity, " kWh"] }), _jsx("div", { style: { display: 'flex', gap: '4px', marginTop: '16px' }, children: Array.from({ length: 5 }).map((_, i) => (_jsx("div", { style: {
                                 width: '8px',
                                 background: BRAND.gold,

--- a/src/pages/ProductCatalog.tsx
+++ b/src/pages/ProductCatalog.tsx
@@ -319,7 +319,7 @@ const ProductCatalog = () => {
         e.currentTarget.style.borderColor = BRAND.creamDark;
       }}
     >
-      <div 
+      <div
         style={{
           position: 'absolute',
           top: '16px',
@@ -330,7 +330,8 @@ const ProductCatalog = () => {
           borderRadius: '20px',
           fontSize: '12px',
           fontWeight: 'bold',
-          boxShadow: '0 4px 12px rgba(0,0,0,0.2)'
+          boxShadow: '0 4px 12px rgba(0,0,0,0.2)',
+          zIndex: 30
         }}
       >
         {panel.badge}
@@ -347,7 +348,8 @@ const ProductCatalog = () => {
         gridTemplateRows: 'repeat(10, 1fr)',
         gap: '2px',
         padding: '8px',
-        position: 'relative'
+        position: 'relative',
+        zIndex: 0
       }}>
         {Array.from({ length: 60 }).map((_, i) => (
           <div key={i} style={{
@@ -366,7 +368,8 @@ const ProductCatalog = () => {
           borderRadius: '8px',
           fontSize: '14px',
           fontWeight: 'bold',
-          boxShadow: '0 4px 12px rgba(0,0,0,0.3)'
+          boxShadow: '0 4px 12px rgba(0,0,0,0.3)',
+          zIndex: 20
         }}>
           {panel.watts}W
         </div>
@@ -486,7 +489,8 @@ const ProductCatalog = () => {
           borderRadius: '20px',
           fontSize: '12px',
           fontWeight: 'bold',
-          boxShadow: '0 4px 12px rgba(0,0,0,0.2)'
+          boxShadow: '0 4px 12px rgba(0,0,0,0.2)',
+          zIndex: 30
         }}
       >
         {battery.badge}
@@ -502,7 +506,8 @@ const ProductCatalog = () => {
         flexDirection: 'column',
         alignItems: 'center',
         justifyContent: 'center',
-        position: 'relative'
+        position: 'relative',
+        zIndex: 0
       }}>
         <Battery size={64} style={{ color: BRAND.gold }} strokeWidth={1.5} />
         <div style={{
@@ -515,7 +520,8 @@ const ProductCatalog = () => {
           borderRadius: '8px',
           fontSize: '14px',
           fontWeight: 'bold',
-          boxShadow: '0 4px 12px rgba(0,0,0,0.3)'
+          boxShadow: '0 4px 12px rgba(0,0,0,0.3)',
+          zIndex: 20
         }}>
           {battery.capacity} kWh
         </div>


### PR DESCRIPTION
## Summary
- ensure the Netlify build command matches the Vite setup and tidy the shared Tailwind base stylesheet
- hide catalog and calculator nav links on the landing page header while leaving them available on other routes
- raise the badge z-index on catalog cards so labels consistently sit above the artwork for panels and batteries

## Testing
- npm run build *(fails: vite binary missing in container due to npm install being blocked by registry restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68e3d79ce39883268899bada454dc581